### PR TITLE
Warn as error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,7 +162,7 @@ write_basic_package_version_file(
 # Add compiler warnings
 if (NOT MSVC)
     target_compile_options(${SEE_OBJ_LIB}
-        PRIVATE -W -Wall -Wextra -pedantic
+        PRIVATE -W -Wall -Wextra -pedantic -Werror
         )
 else()
     target_compile_options(${SEE_OBJ_LIB}

--- a/src/CopyError.c
+++ b/src/CopyError.c
@@ -123,7 +123,7 @@ static int see_copy_error_class_init(SeeObjectClass* new_cls)
 int
 see_copy_error_init()
 {
-    int ret;
+    int ret = SEE_SUCCESS;
     if (g_SeeCopyErrorClass)
         return SEE_SUCCESS;
 
@@ -155,7 +155,7 @@ see_copy_error_init()
     while (g_copy_error_initialize != 0) // Something is still initializing
         ; // TODO It would be better to yield the processor for other threads.
 
-    return g_SeeCopyErrorClass != NULL ? SEE_SUCCESS : SEE_NOT_INITIALIZED;
+    return ret;
 }
 
 void

--- a/src/Error.c
+++ b/src/Error.c
@@ -197,7 +197,7 @@ see_error_class_init(SeeObjectClass* new_cls)
  */
 int
 see_error_init() {
-    int ret;
+    int ret = SEE_SUCCESS;
 
     if (g_SeeErrorClass)
         return SEE_SUCCESS;

--- a/src/MsgBuffer.c
+++ b/src/MsgBuffer.c
@@ -1742,7 +1742,9 @@ msg_buffer_add_part(
 {
     int ret;
     size_t size;
+#if !defined(NDEBUG)
     const SeeMsgBufferClass* cls = SEE_MSG_BUFFER_GET_CLASS(mbuf);
+#endif
     SeeMsgPart* copy = NULL;
 
     ret = see_object_copy(

--- a/src/MsgBuffer.c
+++ b/src/MsgBuffer.c
@@ -209,7 +209,7 @@ static int msg_part_equal(
             assert(0 == 1);
             return SEE_INVALID_ARGUMENT;
     }
-    return SEE_SUCCESS;
+    return ret;
 }
 
 static int

--- a/src/Serial.c
+++ b/src/Serial.c
@@ -152,7 +152,9 @@ obtain_synced_msg_buffer(
     uint16_t id;
     uint32_t size;
     const SeeSerialClass* cls = SEE_SERIAL_GET_CLASS(self);
+#if !defined(NDEBUG)
     const SeeMsgBuffer* buf = NULL; // used for sizeof operation below.
+#endif
     int ret = SEE_SUCCESS;
     size_t num_to_read;
     char* bytes = NULL;

--- a/src/Serial.c
+++ b/src/Serial.c
@@ -91,7 +91,7 @@ init(const SeeObjectClass* cls, SeeObject* obj, va_list args)
 static void
 serial_destroy(SeeObject* obj)
 {
-    int ret, open;
+    int open = 0;
     if (!obj)
         return;
     SeeSerial* serial = SEE_SERIAL(obj);
@@ -100,8 +100,7 @@ serial_destroy(SeeObject* obj)
         );
 
     assert(cls->is_open);
-    ret  = cls->is_open(serial, &open);
-    assert(ret == SEE_SUCCESS);
+    cls->is_open(serial, &open);
     SeeError* error = NULL;
     if (open)
         cls->close(serial, &error);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,7 +72,7 @@ if (BUILD_UNIT_TESTS)
     # Add compiler warnings
     if (NOT MSVC)
         target_compile_options(${UNIT_TEST}
-            PRIVATE -W -Wall -Wextra -pedantic
+            PRIVATE -W -Wall -Wextra -pedantic -Werror
             )
     else()
         target_compile_options(

--- a/test/serial_test.c
+++ b/test/serial_test.c
@@ -50,8 +50,9 @@ void serial_use_unopened(void)
     SeeError*  error    = NULL;
 
     char buffer[] = "Hello serial world.";
-    char read_buf[1024] = {0};
-    size_t bufsz = sizeof(buffer);
+    const size_t bufsz = 1024;
+    size_t sz = bufsz;
+    char* read_buf = calloc(1, bufsz);
 
     int ret = see_serial_new(&serial, &error);
     SEE_UNIT_HANDLE_ERROR();
@@ -62,7 +63,7 @@ void serial_use_unopened(void)
     CU_ASSERT_EQUAL(ret, SEE_SUCCESS);
 
     char* buf_start = &buffer[0];
-    ret = see_serial_write(serial, &buf_start, &bufsz, &error);
+    ret = see_serial_write(serial, &buf_start, &sz, &error);
     CU_ASSERT_EQUAL(ret, SEE_ERROR_RUNTIME);
 #if HAVE_WINDOWS_H
     CU_ASSERT_EQUAL(
@@ -82,9 +83,9 @@ void serial_use_unopened(void)
         error = NULL;
     }
 
-    bufsz = sizeof(buffer);
+    sz = bufsz;
     char** buf_ptr_ref = &read_buf;
-    ret = see_serial_read(serial, buf_ptr_ref, &bufsz, &error);
+    ret = see_serial_read(serial, buf_ptr_ref, &sz, &error);
     CU_ASSERT_EQUAL(ret, SEE_ERROR_RUNTIME);
 #if HAVE_WINDOWS_H
     CU_ASSERT_EQUAL(
@@ -107,6 +108,7 @@ void serial_use_unopened(void)
 fail:
     see_object_decref(SEE_OBJECT(serial));
     see_object_decref(SEE_OBJECT(error));
+    free(read_buf);
 }
 
 int add_serial_suite(void)

--- a/test/unit_test.c
+++ b/test/unit_test.c
@@ -73,6 +73,10 @@ int main(int argc, char** argv) {
 
     int ret = see_init();
     assert(ret == SEE_SUCCESS);
+    if (ret) {
+        fprintf(stderr, "Unable to init the see-objects library\n");
+        return 1;
+    }
 
     add_suites();
 


### PR DESCRIPTION
Currently, compiler warnings are not treated as errors. This is now changed to treat them as errors. All compiler warnings should be fixed after this build passes CI.