### PR TITLE
CI: .travis .yaml rm sudo: false; it is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 
 language: c
 
-sudo: false
-
 git:
   depth: 1
 


### PR DESCRIPTION
Upate the .travis.yml.

The yaml includede
`sudo: false`
however, that is deprecated.
